### PR TITLE
feat: `relfection-build` now supports `REFLECTION_SOURCE_DIRS` and `REFLECTION_DIST_DIR` env vars.

### DIFF
--- a/packages/reflection-build/src/parser/createSourceGraph.ts
+++ b/packages/reflection-build/src/parser/createSourceGraph.ts
@@ -5,30 +5,39 @@ import { TypescriptParser } from '../../modules/typescript-parser';
 import { promisifiedFs } from '@proteinjs/util-node';
 import { createGraphBuilder } from './createGraphBuilder';
 
-export async function createSourceGraph(dir: string, excludedDirs: string[] = []) {
+export async function createSourceGraph(
+  dir: string,
+  excludedDirs: string[] = [],
+  sourceRootsRel: string | string[] = 'src'
+) {
   const packageJsonPath = path.join(dir, 'package.json');
   if (!(await promisifiedFs.exists(packageJsonPath))) {
     throw new Error(`Unable to find package.json in dir: ${dir}`);
   }
 
   const packageJson = require(packageJsonPath);
-  const sourceFilePaths = await globby(
-    [path.join(dir, 'src/**/*.ts'), path.join(dir, 'src/**/*.tsx'), '!**/node_modules/**'].concat(
-      excludedDirs.map((dir) => `!${dir}`)
-    )
-  );
+  const roots = Array.isArray(sourceRootsRel) ? sourceRootsRel : [sourceRootsRel];
+
+  const patterns: string[] = [];
+  for (const rel of roots) {
+    const root = path.join(dir, rel);
+    patterns.push(path.join(root, '**/*.ts'));
+    patterns.push(path.join(root, '**/*.tsx'));
+  }
+
+  const excludePatterns = ['!**/node_modules/**', '!**/generated/**', ...excludedDirs.map((d) => `!${d}`)];
+
+  const sourceFilePaths = await globby([...patterns, ...excludePatterns]);
+  const uniqueFilePaths = Array.from(new Set(sourceFilePaths));
+
   const graph = new graphlib.Graph();
   const addSourceFile = createGraphBuilder(graph, packageJson, dir);
   const parser = new TypescriptParser();
-  for (const sourceFilePath of sourceFilePaths) {
+
+  for (const sourceFilePath of uniqueFilePaths) {
     const sourceFile = await parser.parseFile(sourceFilePath, path.dirname(sourceFilePath));
-    // console.log(`File imports (${sourceFile.filePath}): ${JSON.stringify(sourceFile.imports, null, 2)}`);
     await addSourceFile(sourceFile);
   }
-
-  // for (const node of graph.nodes()) {
-  // 	console.log(JSON.stringify(graph.node(node), null, 2));
-  // }
 
   return graph;
 }


### PR DESCRIPTION
This enables configuration over which dirs reflection metadata is generated from, and where it is written out to.

This is useful for writing tests that test code that leverages reflection.